### PR TITLE
FIX: SQL statements

### DIFF
--- a/src/main/java/mops/persistence/FileInfoRepository.java
+++ b/src/main/java/mops/persistence/FileInfoRepository.java
@@ -33,7 +33,7 @@ public interface FileInfoRepository extends CrudRepository<FileInfo, Long> {
      * @return total storage usage in bytes
      */
     @Query("SELECT COALESCE(SUM(size), 0) FROM file_info "
-            + "LEFT JOIN directory "
+            + "INNER JOIN directory "
             + "ON file_info.directory_id = directory.id "
             + "WHERE group_owner = :groupId")
     long getStorageUsageInGroup(@Param("groupId") long groupId);
@@ -53,7 +53,7 @@ public interface FileInfoRepository extends CrudRepository<FileInfo, Long> {
      * @return total file count
      */
     @Query("SELECT COALESCE(COUNT(*), 0) FROM file_info "
-            + "LEFT JOIN directory "
+            + "INNER JOIN directory "
             + "ON file_info.directory_id = directory.id "
             + "WHERE group_owner = :groupId")
     long getFileCountInGroup(@Param("groupId") long groupId);


### PR DESCRIPTION
'LEFT JOIN' would count / sum up all orphaned FileInfos (between garbage collector cycles)  for each group. "Orphaned" in this context means, that the parent directory of a FileInfo does not exist anymore, which shouldn't ever happen, but better safe than sorry. 