### PR TITLE
REMOVE: generic eception catching

### DIFF
--- a/src/main/java/mops/businesslogic/directory/DirectoryServiceImpl.java
+++ b/src/main/java/mops/businesslogic/directory/DirectoryServiceImpl.java
@@ -72,7 +72,7 @@ public class DirectoryServiceImpl implements DirectoryService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings({ "PMD.AvoidCatchingGenericException", "PMD.LawOfDemeter" })
+    @SuppressWarnings("PMD.LawOfDemeter")
     public List<Directory> getSubFolders(Account account, long parentDirID) throws MopsException {
         Directory directory = getDirectory(parentDirID);
         securityService.checkReadPermission(account, directory);
@@ -86,7 +86,7 @@ public class DirectoryServiceImpl implements DirectoryService {
                 directories = removeNoReadPermissionDirectories(account, directories);
             }
             return directories;
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Subfolders of parent folder with id '{}' could not be loaded:", parentDirID, e);
             throw new DatabaseException("Unterordner konnten nicht geladen werden.", e);
         }
@@ -136,15 +136,14 @@ public class DirectoryServiceImpl implements DirectoryService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings({ "PMD.LawOfDemeter", "PMD.OnlyOneReturn", "PMD.DataflowAnomalyAnalysis",
-            "PMD.AvoidCatchingGenericException" })
+    @SuppressWarnings({ "PMD.LawOfDemeter", "PMD.OnlyOneReturn", "PMD.DataflowAnomalyAnalysis" })
     public GroupRootDirWrapper getOrCreateRootFolder(long groupId) throws MopsException {
         Optional<GroupRootDirWrapper> optRootDir;
         try {
             optRootDir = directoryRepository
                     .getRootFolder(groupId)
                     .map(GroupRootDirWrapper::new);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Error while searching for root directory of group with id '{}':", groupId, e);
             throw new DatabaseException("Das Wurzelverzeichnis konnte nicht gefunden werden.", e);
         }
@@ -267,11 +266,11 @@ public class DirectoryServiceImpl implements DirectoryService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings({ "PMD.LawOfDemeter", "PMD.AvoidCatchingGenericException" })
+    @SuppressWarnings("PMD.LawOfDemeter")
     public Directory getDirectory(long dirId) throws MopsException {
         try {
             return directoryRepository.findById(dirId).orElseThrow();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("The directory with the id '{}' was requested, but was not found in the database:", dirId, e);
             String error = String.format("Der Ordner mit der ID '%d' konnte nicht gefunden werden.", dirId);
             throw new DatabaseException(error, e);
@@ -282,11 +281,10 @@ public class DirectoryServiceImpl implements DirectoryService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public Directory saveDirectory(Directory directory) throws MopsException {
         try {
             return directoryRepository.save(directory);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("The directory with the id '{}' could not be saved to the database:", directory, e);
             String error = String.format("Der Ordner '%s' konnte nicht gespeichert werden.", directory.getName());
             if (e.getCause() instanceof DuplicateKeyException) {
@@ -300,11 +298,10 @@ public class DirectoryServiceImpl implements DirectoryService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public void deleteDirectory(Directory directory) throws MopsException {
         try {
             directoryRepository.delete(directory);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("The directory '{}' could not be deleted from the database:", directory, e);
             String error = String.format("Der Ordner '%s' konnte nicht gelöscht werden.", directory);
             throw new DatabaseException(error, e);
@@ -315,11 +312,10 @@ public class DirectoryServiceImpl implements DirectoryService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public long getDirCountInGroup(long groupId) throws MopsException {
         try {
             return directoryRepository.getDirCountInGroup(groupId);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to get total directory count in group with id '{}':", groupId, e);
             throw new DatabaseException("Gesamtordneranzahl konnte nicht geladen werden!", e);
         }
@@ -329,11 +325,10 @@ public class DirectoryServiceImpl implements DirectoryService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public long getTotalDirCount() throws MopsException {
         try {
             return directoryRepository.count();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to get total directory count:", e);
             throw new DatabaseException("Gesamtordneranzahl konnte nicht geladen werden!", e);
         }
@@ -378,11 +373,10 @@ public class DirectoryServiceImpl implements DirectoryService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public List<Directory> getAllRootDirectories() throws MopsException {
         try {
             return directoryRepository.getAllRootDirectories();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to get all root directories:", e);
             throw new DatabaseException("Die Wurzelverzeichnisse konnten nicht geladen werden!", e);
         }

--- a/src/main/java/mops/businesslogic/directory/DirectoryServiceImpl.java
+++ b/src/main/java/mops/businesslogic/directory/DirectoryServiceImpl.java
@@ -22,7 +22,9 @@ import mops.persistence.file.FileInfo;
 import mops.persistence.group.Group;
 import mops.persistence.permission.DirectoryPermissions;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DuplicateKeyException;
+import org.springframework.data.relational.core.conversion.DbActionExecutionException;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -86,7 +88,7 @@ public class DirectoryServiceImpl implements DirectoryService {
                 directories = removeNoReadPermissionDirectories(account, directories);
             }
             return directories;
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Subfolders of parent folder with id '{}' could not be loaded:", parentDirID, e);
             throw new DatabaseException("Unterordner konnten nicht geladen werden.", e);
         }
@@ -143,7 +145,7 @@ public class DirectoryServiceImpl implements DirectoryService {
             optRootDir = directoryRepository
                     .getRootFolder(groupId)
                     .map(GroupRootDirWrapper::new);
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Error while searching for root directory of group with id '{}':", groupId, e);
             throw new DatabaseException("Das Wurzelverzeichnis konnte nicht gefunden werden.", e);
         }
@@ -270,7 +272,7 @@ public class DirectoryServiceImpl implements DirectoryService {
     public Directory getDirectory(long dirId) throws MopsException {
         try {
             return directoryRepository.findById(dirId).orElseThrow();
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("The directory with the id '{}' was requested, but was not found in the database:", dirId, e);
             String error = String.format("Der Ordner mit der ID '%d' konnte nicht gefunden werden.", dirId);
             throw new DatabaseException(error, e);
@@ -284,7 +286,7 @@ public class DirectoryServiceImpl implements DirectoryService {
     public Directory saveDirectory(Directory directory) throws MopsException {
         try {
             return directoryRepository.save(directory);
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("The directory with the id '{}' could not be saved to the database:", directory, e);
             String error = String.format("Der Ordner '%s' konnte nicht gespeichert werden.", directory.getName());
             if (e.getCause() instanceof DuplicateKeyException) {
@@ -301,7 +303,7 @@ public class DirectoryServiceImpl implements DirectoryService {
     public void deleteDirectory(Directory directory) throws MopsException {
         try {
             directoryRepository.delete(directory);
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("The directory '{}' could not be deleted from the database:", directory, e);
             String error = String.format("Der Ordner '%s' konnte nicht gelöscht werden.", directory);
             throw new DatabaseException(error, e);
@@ -315,7 +317,7 @@ public class DirectoryServiceImpl implements DirectoryService {
     public long getDirCountInGroup(long groupId) throws MopsException {
         try {
             return directoryRepository.getDirCountInGroup(groupId);
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to get total directory count in group with id '{}':", groupId, e);
             throw new DatabaseException("Gesamtordneranzahl konnte nicht geladen werden!", e);
         }
@@ -328,7 +330,7 @@ public class DirectoryServiceImpl implements DirectoryService {
     public long getTotalDirCount() throws MopsException {
         try {
             return directoryRepository.count();
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to get total directory count:", e);
             throw new DatabaseException("Gesamtordneranzahl konnte nicht geladen werden!", e);
         }
@@ -376,7 +378,7 @@ public class DirectoryServiceImpl implements DirectoryService {
     public List<Directory> getAllRootDirectories() throws MopsException {
         try {
             return directoryRepository.getAllRootDirectories();
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to get all root directories:", e);
             throw new DatabaseException("Die Wurzelverzeichnisse konnten nicht geladen werden!", e);
         }

--- a/src/main/java/mops/businesslogic/event/LatestEventIdService.java
+++ b/src/main/java/mops/businesslogic/event/LatestEventIdService.java
@@ -6,6 +6,8 @@ import mops.businesslogic.exception.DatabaseException;
 import mops.exception.MopsException;
 import mops.persistence.LatestEventIdRepository;
 import mops.persistence.event.LatestEventId;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.relational.core.conversion.DbActionExecutionException;
 import org.springframework.stereotype.Service;
 
 /**
@@ -27,11 +29,11 @@ public class LatestEventIdService {
      * @return loaded latest event id
      * @throws MopsException on error
      */
-    @SuppressWarnings({ "PMD.AvoidCatchingGenericException", "PMD.LawOfDemeter" }) // optional fluent api
+    @SuppressWarnings("PMD.LawOfDemeter") // optional fluent api
     public LatestEventId getLatestEventId() throws MopsException {
         try {
             return latestEventIdRepository.findById(0L).orElse(LatestEventId.of());
-        } catch (Exception e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to get latest event id database:", e);
             throw new DatabaseException("Neueste Event Id konnte nicht geladen werden!", e);
         }
@@ -43,11 +45,10 @@ public class LatestEventIdService {
      * @param latestEventId latest event id to save
      * @throws MopsException on error
      */
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public void saveLatestEventId(LatestEventId latestEventId) throws MopsException {
         try {
             latestEventIdRepository.save(latestEventId);
-        } catch (Exception e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to save latest event id database:", e);
             throw new DatabaseException("Neueste Event Id konnte nicht gespeichert werden!", e);
         }

--- a/src/main/java/mops/businesslogic/file/FileInfoServiceImpl.java
+++ b/src/main/java/mops/businesslogic/file/FileInfoServiceImpl.java
@@ -30,14 +30,13 @@ public class FileInfoServiceImpl implements FileInfoService {
     /**
      * {@inheritDoc}
      */
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     @Override
     public List<FileInfo> fetchAllFilesInDirectory(long dirId) throws MopsException {
         try {
             List<FileInfo> fileInfos = new ArrayList<>(fileInfoRepo.findAllInDirectory(dirId));
             fileInfos.sort(FileInfo.NAME_COMPARATOR);
             return fileInfos;
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to retrieve all files in directory with id {} from the database:", dirId, e);
             throw new DatabaseException("Es konnten nicht alle Dateien im Verzeichnis gefunden werden!", e);
         }
@@ -46,12 +45,12 @@ public class FileInfoServiceImpl implements FileInfoService {
     /**
      * {@inheritDoc}
      */
-    @SuppressWarnings({ "PMD.LawOfDemeter", "PMD.AvoidCatchingGenericException" })
+    @SuppressWarnings("PMD.LawOfDemeter")
     @Override
     public FileInfo fetchFileInfo(long fileId) throws MopsException {
         try {
             return fileInfoRepo.findById(fileId).orElseThrow();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to retrieve file info for file with id {} from the database:", fileId, e);
             throw new DatabaseException("Die Datei-Informationen konnten nicht gefunden werden!", e);
         }
@@ -60,12 +59,11 @@ public class FileInfoServiceImpl implements FileInfoService {
     /**
      * {@inheritDoc}
      */
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     @Override
     public FileInfo saveFileInfo(FileInfo fileInfo) throws MopsException {
         try {
             return fileInfoRepo.save(fileInfo);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             if (e.getCause() instanceof DuplicateKeyException) {
                 log.error("The file '{}'  already exists in the directory '{}’.",
                         fileInfo.getDirectoryId(),
@@ -85,12 +83,11 @@ public class FileInfoServiceImpl implements FileInfoService {
     /**
      * {@inheritDoc}
      */
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     @Override
     public void deleteFileInfo(long fileId) throws MopsException {
         try {
             fileInfoRepo.deleteById(fileId);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to delete file with id {}:", fileId, e);
             throw new DatabaseException("Datei-Informationen konnten nicht gelöscht werden!", e);
         }
@@ -100,11 +97,10 @@ public class FileInfoServiceImpl implements FileInfoService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public long getStorageUsageInGroup(long groupId) throws MopsException {
         try {
             return fileInfoRepo.getStorageUsageInGroup(groupId);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to get total storage used by group with id {}:", groupId, e);
             throw new DatabaseException("Gesamtspeicherplatz konnte nicht geladen werden!", e);
         }
@@ -114,11 +110,10 @@ public class FileInfoServiceImpl implements FileInfoService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public long getTotalStorageUsage() throws MopsException {
         try {
             return fileInfoRepo.getTotalStorageUsage();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to get total storage used:", e);
             throw new DatabaseException("Gesamtspeicherplatz konnte nicht geladen werden!", e);
         }
@@ -128,11 +123,10 @@ public class FileInfoServiceImpl implements FileInfoService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public long getFileCountInGroup(long groupId) throws MopsException {
         try {
             return fileInfoRepo.getFileCountInGroup(groupId);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to get total file count in group with id {}:", groupId, e);
             throw new DatabaseException("Gesamtdateianzahl konnte nicht geladen werden!", e);
         }
@@ -142,11 +136,10 @@ public class FileInfoServiceImpl implements FileInfoService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public long getTotalFileCount() throws MopsException {
         try {
             return fileInfoRepo.count();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to get total file count:", e);
             throw new DatabaseException("Gesamtdateianzahl konnte nicht geladen werden!", e);
         }
@@ -156,11 +149,10 @@ public class FileInfoServiceImpl implements FileInfoService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public Set<Long> fetchAllFileInfoIds() throws MopsException {
         try {
             return fileInfoRepo.findAllIds();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to get all FileInfo ids:", e);
             throw new MopsException("IDs konnten nicht gefunden werden.", e);
         }
@@ -170,11 +162,10 @@ public class FileInfoServiceImpl implements FileInfoService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public Set<Long> fetchAllOrphanedFileInfos() throws MopsException {
         try {
             return fileInfoRepo.findAllOrphansByDirectory();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to find all orphaned file infos:", e);
             throw new MopsException("Verwaiste IDs konnten nicht gefunden werden.", e);
         }

--- a/src/main/java/mops/businesslogic/file/FileInfoServiceImpl.java
+++ b/src/main/java/mops/businesslogic/file/FileInfoServiceImpl.java
@@ -7,7 +7,9 @@ import mops.businesslogic.exception.DatabaseException;
 import mops.exception.MopsException;
 import mops.persistence.FileInfoRepository;
 import mops.persistence.file.FileInfo;
+import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DuplicateKeyException;
+import org.springframework.data.relational.core.conversion.DbActionExecutionException;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -36,7 +38,7 @@ public class FileInfoServiceImpl implements FileInfoService {
             List<FileInfo> fileInfos = new ArrayList<>(fileInfoRepo.findAllInDirectory(dirId));
             fileInfos.sort(FileInfo.NAME_COMPARATOR);
             return fileInfos;
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to retrieve all files in directory with id {} from the database:", dirId, e);
             throw new DatabaseException("Es konnten nicht alle Dateien im Verzeichnis gefunden werden!", e);
         }
@@ -50,7 +52,7 @@ public class FileInfoServiceImpl implements FileInfoService {
     public FileInfo fetchFileInfo(long fileId) throws MopsException {
         try {
             return fileInfoRepo.findById(fileId).orElseThrow();
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to retrieve file info for file with id {} from the database:", fileId, e);
             throw new DatabaseException("Die Datei-Informationen konnten nicht gefunden werden!", e);
         }
@@ -63,7 +65,7 @@ public class FileInfoServiceImpl implements FileInfoService {
     public FileInfo saveFileInfo(FileInfo fileInfo) throws MopsException {
         try {
             return fileInfoRepo.save(fileInfo);
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             if (e.getCause() instanceof DuplicateKeyException) {
                 log.error("The file '{}'  already exists in the directory '{}’.",
                         fileInfo.getDirectoryId(),
@@ -87,7 +89,7 @@ public class FileInfoServiceImpl implements FileInfoService {
     public void deleteFileInfo(long fileId) throws MopsException {
         try {
             fileInfoRepo.deleteById(fileId);
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to delete file with id {}:", fileId, e);
             throw new DatabaseException("Datei-Informationen konnten nicht gelöscht werden!", e);
         }
@@ -100,7 +102,7 @@ public class FileInfoServiceImpl implements FileInfoService {
     public long getStorageUsageInGroup(long groupId) throws MopsException {
         try {
             return fileInfoRepo.getStorageUsageInGroup(groupId);
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to get total storage used by group with id {}:", groupId, e);
             throw new DatabaseException("Gesamtspeicherplatz konnte nicht geladen werden!", e);
         }
@@ -113,7 +115,7 @@ public class FileInfoServiceImpl implements FileInfoService {
     public long getTotalStorageUsage() throws MopsException {
         try {
             return fileInfoRepo.getTotalStorageUsage();
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to get total storage used:", e);
             throw new DatabaseException("Gesamtspeicherplatz konnte nicht geladen werden!", e);
         }
@@ -126,7 +128,7 @@ public class FileInfoServiceImpl implements FileInfoService {
     public long getFileCountInGroup(long groupId) throws MopsException {
         try {
             return fileInfoRepo.getFileCountInGroup(groupId);
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to get total file count in group with id {}:", groupId, e);
             throw new DatabaseException("Gesamtdateianzahl konnte nicht geladen werden!", e);
         }
@@ -139,7 +141,7 @@ public class FileInfoServiceImpl implements FileInfoService {
     public long getTotalFileCount() throws MopsException {
         try {
             return fileInfoRepo.count();
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to get total file count:", e);
             throw new DatabaseException("Gesamtdateianzahl konnte nicht geladen werden!", e);
         }
@@ -152,7 +154,7 @@ public class FileInfoServiceImpl implements FileInfoService {
     public Set<Long> fetchAllFileInfoIds() throws MopsException {
         try {
             return fileInfoRepo.findAllIds();
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to get all FileInfo ids:", e);
             throw new MopsException("IDs konnten nicht gefunden werden.", e);
         }
@@ -165,7 +167,7 @@ public class FileInfoServiceImpl implements FileInfoService {
     public Set<Long> fetchAllOrphanedFileInfos() throws MopsException {
         try {
             return fileInfoRepo.findAllOrphansByDirectory();
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to find all orphaned file infos:", e);
             throw new MopsException("Verwaiste IDs konnten nicht gefunden werden.", e);
         }

--- a/src/main/java/mops/businesslogic/group/GroupServiceImpl.java
+++ b/src/main/java/mops/businesslogic/group/GroupServiceImpl.java
@@ -52,12 +52,12 @@ public class GroupServiceImpl implements GroupService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings({ "PMD.AvoidCatchingGenericException", "PMD.LawOfDemeter" }) // iterable fluent api
+    @SuppressWarnings("PMD.LawOfDemeter") // iterable fluent api
     public List<Group> getAllGroups() throws MopsException {
         List<Group> groups = new ArrayList<>();
         try {
             groupRepository.findAll().forEach(groups::add);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Error while getting all groups:", e);
             throw new DatabaseException("Konnte nicht alle Gruppen laden.", e);
         }
@@ -68,11 +68,10 @@ public class GroupServiceImpl implements GroupService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public List<Group> getUserGroups(Account account) throws MopsException {
         try {
             return groupRepository.findByUser(account.getName());
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Error while getting all groups for user {}:", account.getName(), e);
             throw new DatabaseException("Konnte nicht alle Gruppen eines Benutzers laden.", e);
         }
@@ -94,11 +93,11 @@ public class GroupServiceImpl implements GroupService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings({ "PMD.LawOfDemeter", "PMD.AvoidCatchingGenericException" })
+    @SuppressWarnings("PMD.LawOfDemeter")
     public Group getGroup(long groupId) throws MopsException {
         try {
             return groupRepository.findById(groupId).orElseThrow();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to retrieve group with id '{}':", groupId, e);
             throw new DatabaseException(
                     "Die Gruppe konnte nicht gefunden werden, bitte versuchen sie es später nochmal!", e);
@@ -109,11 +108,11 @@ public class GroupServiceImpl implements GroupService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings({ "PMD.LawOfDemeter", "PMD.AvoidCatchingGenericException" })
+    @SuppressWarnings("PMD.LawOfDemeter")
     public Optional<Group> findGroupByGroupId(UUID groupId) throws MopsException {
         try {
             return groupRepository.findByGroupId(groupId);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to retrieve group with group uuid '{}':", groupId, e);
             throw new DatabaseException(
                     "Die Gruppe konnte nicht gefunden werden, bitte versuchen sie es später nochmal!", e);
@@ -124,11 +123,11 @@ public class GroupServiceImpl implements GroupService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings({ "PMD.LawOfDemeter", "PMD.AvoidCatchingGenericException" })
+    @SuppressWarnings("PMD.LawOfDemeter")
     public Group saveGroup(Group group) throws MopsException {
         try {
             return groupRepository.save(group);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to save group '{}' with group uuid '{}':", group.getName(), group.getGroupId(), e);
             throw new DatabaseException("Die Gruppe konnte nicht gespeichert werden!", e);
         }
@@ -138,11 +137,11 @@ public class GroupServiceImpl implements GroupService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings({ "PMD.LawOfDemeter", "PMD.AvoidCatchingGenericException" })
+    @SuppressWarnings("PMD.LawOfDemeter")
     public void deleteGroup(long groupId) throws MopsException {
         try {
             groupRepository.deleteById(groupId);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to delete group with id '{}':", groupId, e);
             throw new DatabaseException("Die Gruppe konnte nicht gelöscht werden!", e);
         }
@@ -152,11 +151,10 @@ public class GroupServiceImpl implements GroupService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public long getTotalGroupCount() throws MopsException {
         try {
             return groupRepository.count();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to get total group count:", e);
             throw new DatabaseException("Gesamtgruppenzahl konnte nicht geladen werden!", e);
         }

--- a/src/main/java/mops/businesslogic/group/GroupServiceImpl.java
+++ b/src/main/java/mops/businesslogic/group/GroupServiceImpl.java
@@ -9,6 +9,8 @@ import mops.persistence.GroupRepository;
 import mops.persistence.group.Group;
 import mops.persistence.permission.DirectoryPermissions;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.relational.core.conversion.DbActionExecutionException;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -22,6 +24,10 @@ import java.util.*;
 public class GroupServiceImpl implements GroupService {
 
     /**
+     * Access to our Group Database.
+     */
+    private final GroupRepository groupRepository;
+    /**
      * Represents the role of an admin.
      */
     @Value("${material1.mops.configuration.role.admin}")
@@ -33,11 +39,6 @@ public class GroupServiceImpl implements GroupService {
     @Value("${material1.mops.configuration.role.viewer}")
     @SuppressWarnings({ "PMD.ImmutableField", "PMD.BeanMembersShouldSerialize" })
     private String viewerRole = "viewer";
-
-    /**
-     * Access to our Group Database.
-     */
-    private final GroupRepository groupRepository;
 
     /**
      * {@inheritDoc}
@@ -57,7 +58,7 @@ public class GroupServiceImpl implements GroupService {
         List<Group> groups = new ArrayList<>();
         try {
             groupRepository.findAll().forEach(groups::add);
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Error while getting all groups:", e);
             throw new DatabaseException("Konnte nicht alle Gruppen laden.", e);
         }
@@ -71,7 +72,7 @@ public class GroupServiceImpl implements GroupService {
     public List<Group> getUserGroups(Account account) throws MopsException {
         try {
             return groupRepository.findByUser(account.getName());
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Error while getting all groups for user {}:", account.getName(), e);
             throw new DatabaseException("Konnte nicht alle Gruppen eines Benutzers laden.", e);
         }
@@ -97,7 +98,7 @@ public class GroupServiceImpl implements GroupService {
     public Group getGroup(long groupId) throws MopsException {
         try {
             return groupRepository.findById(groupId).orElseThrow();
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to retrieve group with id '{}':", groupId, e);
             throw new DatabaseException(
                     "Die Gruppe konnte nicht gefunden werden, bitte versuchen sie es später nochmal!", e);
@@ -112,7 +113,7 @@ public class GroupServiceImpl implements GroupService {
     public Optional<Group> findGroupByGroupId(UUID groupId) throws MopsException {
         try {
             return groupRepository.findByGroupId(groupId);
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to retrieve group with group uuid '{}':", groupId, e);
             throw new DatabaseException(
                     "Die Gruppe konnte nicht gefunden werden, bitte versuchen sie es später nochmal!", e);
@@ -127,7 +128,7 @@ public class GroupServiceImpl implements GroupService {
     public Group saveGroup(Group group) throws MopsException {
         try {
             return groupRepository.save(group);
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to save group '{}' with group uuid '{}':", group.getName(), group.getGroupId(), e);
             throw new DatabaseException("Die Gruppe konnte nicht gespeichert werden!", e);
         }
@@ -141,7 +142,7 @@ public class GroupServiceImpl implements GroupService {
     public void deleteGroup(long groupId) throws MopsException {
         try {
             groupRepository.deleteById(groupId);
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to delete group with id '{}':", groupId, e);
             throw new DatabaseException("Die Gruppe konnte nicht gelöscht werden!", e);
         }
@@ -154,7 +155,7 @@ public class GroupServiceImpl implements GroupService {
     public long getTotalGroupCount() throws MopsException {
         try {
             return groupRepository.count();
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to get total group count:", e);
             throw new DatabaseException("Gesamtgruppenzahl konnte nicht geladen werden!", e);
         }

--- a/src/main/java/mops/businesslogic/gruppenbildung/GruppenbildungsService.java
+++ b/src/main/java/mops/businesslogic/gruppenbildung/GruppenbildungsService.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
@@ -44,7 +45,7 @@ public class GruppenbildungsService {
      * @param groupId group id to test
      * @return true if it exists
      */
-    @SuppressWarnings({ "PMD.AvoidCatchingGenericException", "PMD.LawOfDemeter" })
+    @SuppressWarnings("PMD.LawOfDemeter")
     @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "NPE is intended and caught")
     public boolean doesGroupExist(UUID groupId) throws MopsException {
         try {
@@ -58,7 +59,7 @@ public class GruppenbildungsService {
             ).getBody();
             return Objects.requireNonNull(result, "got null response from GET")
                     .get("doesGroupExist");
-        } catch (Exception e) {
+        } catch (RestClientException e) {
             log.error("Error while doing API call 'doesGroupExist' to Gruppenbildung:", e);
             throw new GruppenbildungsException("Fehler beim Aufruf von 'doesGroupExist'.", e);
         }
@@ -71,7 +72,7 @@ public class GruppenbildungsService {
      * @param groupId  group id
      * @return true if the user is a member in the given group
      */
-    @SuppressWarnings({ "PMD.AvoidCatchingGenericException", "PMD.LawOfDemeter" })
+    @SuppressWarnings("PMD.LawOfDemeter")
     @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "NPE is intended and caught")
     public boolean isUserInGroup(String userName, UUID groupId) throws MopsException {
         try {
@@ -86,7 +87,7 @@ public class GruppenbildungsService {
             ).getBody();
             return Objects.requireNonNull(result, "got null response from GET")
                     .get("isUserInGroup");
-        } catch (Exception e) {
+        } catch (RestClientException e) {
             log.error("Error while doing API call 'isUserInGroup' to Gruppenbildung:", e);
             throw new GruppenbildungsException("Fehler beim Aufruf von 'isUserInGroup'.", e);
         }
@@ -99,7 +100,7 @@ public class GruppenbildungsService {
      * @param groupId  group id
      * @return true if the user is an admin in the given group
      */
-    @SuppressWarnings({ "PMD.AvoidCatchingGenericException", "PMD.LawOfDemeter" })
+    @SuppressWarnings("PMD.LawOfDemeter")
     @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "NPE is intended and caught")
     public boolean isUserAdminInGroup(String userName, UUID groupId) throws MopsException {
         try {
@@ -114,7 +115,7 @@ public class GruppenbildungsService {
             ).getBody();
             return Objects.requireNonNull(result, "got null response from GET")
                     .get("isUserAdminInGroup");
-        } catch (Exception e) {
+        } catch (RestClientException e) {
             log.error("Error while doing API call 'isUserAdminInGroup' to Gruppenbildung:", e);
             throw new GruppenbildungsException("Fehler beim Aufruf von 'isUserAdminInGroup'.", e);
         }
@@ -126,7 +127,7 @@ public class GruppenbildungsService {
      * @param lastEventId last event timestamp
      * @return object that contains all updated groups
      */
-    @SuppressWarnings({ "PMD.AvoidCatchingGenericException", "PMD.LawOfDemeter" })
+    @SuppressWarnings("PMD.LawOfDemeter")
     public UpdatedGroupsDTO getUpdatedGroups(long lastEventId) throws MopsException {
         try {
             return restTemplate.exchange(
@@ -136,7 +137,7 @@ public class GruppenbildungsService {
                     UpdatedGroupsDTO.class,
                     String.valueOf(lastEventId)
             ).getBody();
-        } catch (Exception e) {
+        } catch (RestClientException e) {
             log.error("Error while doing API call 'returnAllGroups' to Gruppenbildung:", e);
             throw new GruppenbildungsException("Fehler beim Aufruf von 'returnAllGroups'.", e);
         }
@@ -148,7 +149,6 @@ public class GruppenbildungsService {
      * @param groupId group id
      * @return list of members
      */
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public List<UserDTO> getMembers(UUID groupId) throws MopsException {
         try {
             return restTemplate.exchange(
@@ -159,7 +159,7 @@ public class GruppenbildungsService {
                     },
                     String.valueOf(groupId)
             ).getBody();
-        } catch (Exception e) {
+        } catch (RestClientException e) {
             log.error("Error while doing API call 'returnUsersOfGroup' to Gruppenbildung:", e);
             throw new GruppenbildungsException("Fehler beim Aufruf von 'returnUsersOfGroup'.", e);
         }
@@ -171,7 +171,6 @@ public class GruppenbildungsService {
      * @param userName user name
      * @return list of groups
      */
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public List<GroupDTO> getUserGroups(String userName) throws MopsException {
         try {
             return restTemplate.exchange(
@@ -182,7 +181,7 @@ public class GruppenbildungsService {
                     },
                     userName
             ).getBody();
-        } catch (Exception e) {
+        } catch (RestClientException e) {
             log.error("Error while doing API call 'returnGroupsOfUsers' to Gruppenbildung:", e);
             throw new GruppenbildungsException("Fehler beim Aufruf von 'returnGroupsOfUsers'.", e);
         }

--- a/src/main/java/mops/businesslogic/permission/PermissionServiceImpl.java
+++ b/src/main/java/mops/businesslogic/permission/PermissionServiceImpl.java
@@ -7,6 +7,8 @@ import mops.exception.MopsException;
 import mops.persistence.DirectoryPermissionsRepository;
 import mops.persistence.directory.Directory;
 import mops.persistence.permission.DirectoryPermissions;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.relational.core.conversion.DbActionExecutionException;
 import org.springframework.stereotype.Service;
 
 /**
@@ -31,7 +33,7 @@ public class PermissionServiceImpl implements PermissionService {
         long id = directory.getPermissionsId();
         try {
             return permissionsRepository.findById(id).orElseThrow();
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to retrieve directory permissions with id '{}' for directory with id '{}' and name '{}':",
                     id, directory.getId(), directory.getName(), e);
             String message = String.format("Die Berechtigungen für den Ordner '%s' konnten nicht gefunden werden.",
@@ -47,7 +49,7 @@ public class PermissionServiceImpl implements PermissionService {
     public DirectoryPermissions savePermissions(DirectoryPermissions permissions) throws MopsException {
         try {
             return permissionsRepository.save(permissions);
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to save directory permissions '{}' to database:", permissions, e);
             throw new DatabaseException("Die Ordnerberechtigungen konnten nicht gespeichert werden!", e);
         }
@@ -61,7 +63,7 @@ public class PermissionServiceImpl implements PermissionService {
         long id = directory.getPermissionsId();
         try {
             permissionsRepository.deleteById(id);
-        } catch (RuntimeException e) {
+        } catch (DataAccessException | IllegalArgumentException | DbActionExecutionException e) {
             log.error("Failed to delete directory permissions with id '{}':", id, e);
             String message = String.format("Die Berechtigungen für den Ordner '%s' konnten nicht gelöscht werden.",
                     directory.getName());

--- a/src/main/java/mops/businesslogic/permission/PermissionServiceImpl.java
+++ b/src/main/java/mops/businesslogic/permission/PermissionServiceImpl.java
@@ -26,12 +26,12 @@ public class PermissionServiceImpl implements PermissionService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings({ "PMD.LawOfDemeter", "PMD.AvoidCatchingGenericException" })
+    @SuppressWarnings("PMD.LawOfDemeter")
     public DirectoryPermissions getPermissions(Directory directory) throws MopsException {
         long id = directory.getPermissionsId();
         try {
             return permissionsRepository.findById(id).orElseThrow();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to retrieve directory permissions with id '{}' for directory with id '{}' and name '{}':",
                     id, directory.getId(), directory.getName(), e);
             String message = String.format("Die Berechtigungen für den Ordner '%s' konnten nicht gefunden werden.",
@@ -44,11 +44,10 @@ public class PermissionServiceImpl implements PermissionService {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public DirectoryPermissions savePermissions(DirectoryPermissions permissions) throws MopsException {
         try {
             return permissionsRepository.save(permissions);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to save directory permissions '{}' to database:", permissions, e);
             throw new DatabaseException("Die Ordnerberechtigungen konnten nicht gespeichert werden!", e);
         }
@@ -57,13 +56,12 @@ public class PermissionServiceImpl implements PermissionService {
     /**
      * {@inheritDoc}
      */
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     @Override
     public void deletePermissions(Directory directory) throws MopsException {
         long id = directory.getPermissionsId();
         try {
             permissionsRepository.deleteById(id);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.error("Failed to delete directory permissions with id '{}':", id, e);
             String message = String.format("Die Berechtigungen für den Ordner '%s' konnten nicht gelöscht werden.",
                     directory.getName());

--- a/src/main/java/mops/persistence/FileRepository.java
+++ b/src/main/java/mops/persistence/FileRepository.java
@@ -15,6 +15,7 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
@@ -106,8 +107,7 @@ public class FileRepository {
                     null, // no encryption will be needed
                     type
             );
-        } catch (MinioException | IOException | InvalidKeyException
-                | NoSuchAlgorithmException | XmlPullParserException e) {
+        } catch (MinioException | GeneralSecurityException | XmlPullParserException | IOException e) {
             log.error("Failed so save file '{}' to MinIO server:", fileId, e);
             throw new StorageException("Fehler beim Speichern der Datei.", e);
         }
@@ -125,9 +125,7 @@ public class FileRepository {
                     configuration.getBucketName(),
                     String.valueOf(fileId)
             );
-        } catch (InvalidBucketNameException | NoSuchAlgorithmException | InsufficientDataException
-                | IOException | InvalidKeyException | NoResponseException | XmlPullParserException
-                | ErrorResponseException | InternalException | InvalidArgumentException | InvalidResponseException e) {
+        } catch (MinioException | GeneralSecurityException | XmlPullParserException | IOException e) {
             log.error("Failed to delete file with id {} from MinIO Server:", fileId, e);
             throw new StorageException("Fehler beim Löschen der Datei.", e);
         }
@@ -147,9 +145,7 @@ public class FileRepository {
                     configuration.getBucketName(),
                     String.valueOf(fileId)
             );
-        } catch (IOException | InvalidBucketNameException | NoSuchAlgorithmException | InsufficientDataException
-                | InvalidKeyException | NoResponseException | XmlPullParserException | ErrorResponseException
-                | InternalException | InvalidArgumentException | InvalidResponseException e) {
+        } catch (MinioException | GeneralSecurityException | XmlPullParserException | IOException e) {
             log.error("Failed to get content of file with id {}:", fileId, e);
             throw new StorageException("Fehler beim Zugriff auf den Inhalt der Datei.", e);
         }
@@ -172,9 +168,7 @@ public class FileRepository {
         } catch (ErrorResponseException e) {
             // file not found
             return false;
-        } catch (InvalidKeyException | NoSuchAlgorithmException | NoResponseException | InvalidResponseException
-                | XmlPullParserException | InvalidArgumentException | InsufficientDataException | InternalException
-                | InvalidBucketNameException | IOException e) {
+        } catch (MinioException | GeneralSecurityException | XmlPullParserException | IOException e) {
             log.error("Failed to check file existence for id {}:", fileId, e);
             throw new StorageException("Fehler beim Zugriff auf Datei.", e);
         }
@@ -187,7 +181,7 @@ public class FileRepository {
      *
      * @return all File IDs
      */
-    @SuppressWarnings({ "PMD.AvoidCatchingGenericException", "PMD.LawOfDemeter" })
+    @SuppressWarnings("PMD.LawOfDemeter")
     public Set<Long> getAllIds() throws StorageException {
         try {
             Iterable<Result<Item>> results = minioClient.listObjects(configuration.getBucketName());
@@ -198,7 +192,7 @@ public class FileRepository {
                 );
             }
             return ids;
-        } catch (Exception e) {
+        } catch (MinioException | GeneralSecurityException | XmlPullParserException | IOException e) {
             throw new StorageException("Fehler beim Laden aller File IDs.", e);
         }
     }
@@ -214,9 +208,7 @@ public class FileRepository {
             for (Result<Item> result : minioClient.listObjects(configuration.getBucketName())) {
                 minioClient.removeObject(configuration.getBucketName(), result.get().objectName());
             }
-        } catch (ErrorResponseException | InsufficientDataException | InternalException | InvalidArgumentException
-                | InvalidBucketNameException | InvalidResponseException | NoResponseException | IOException
-                | InvalidKeyException | NoSuchAlgorithmException | XmlPullParserException e) {
+        } catch (MinioException | GeneralSecurityException | XmlPullParserException | IOException e) {
             log.error("Failed to clear bucket:", e);
             throw new StorageException("Bucket konnte nicht geleert werden.", e);
         }


### PR DESCRIPTION
Basically all Spring Data JDBC repositories could throw [DataAccessException](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/dao/DataAccessException.html) or IllegalArgumentException (and DbActionExecutionException :nauseated_face: ) which both extending RuntimeException.
Further the RestTemplate only throws RestClientExceptions.

There was no need to catch generic exceptions and suppress PMD even more. Sometimes it has a right to live his restricting life.


# \# :free: PMD !