### PR TITLE
ADD: better sanitizer for filenames and directory names

### DIFF
--- a/src/main/java/mops/businesslogic/directory/DirectoryServiceImpl.java
+++ b/src/main/java/mops/businesslogic/directory/DirectoryServiceImpl.java
@@ -176,9 +176,7 @@ public class DirectoryServiceImpl implements DirectoryService {
             log.error("The user '{}' tried to create a sub folder with an empty name.", account.getName());
             throw new DatabaseException("Name leer.");
         }
-
-        dirName = dirName.replaceAll("[^a-zA-Z0-9._-]", "_");
-
+        dirName = sanitizeName(dirName);
         Directory parentDir = getDirectory(parentDirId);
         long groupFolderCount = getDirCountInGroup(parentDir.getGroupOwner());
         if (groupFolderCount >= maxFoldersPerGroup) {
@@ -366,7 +364,7 @@ public class DirectoryServiceImpl implements DirectoryService {
             throw new WriteAccessPermissionException("Keine Schreibberechtigung und Löschberechtigung");
         }
 
-        newName = newName.replaceAll("[^a-zA-Z0-9.\\-]", "_");
+        newName = sanitizeName(newName);
         directory.setName(newName);
         return directoryRepository.save(directory);
     }
@@ -382,5 +380,22 @@ public class DirectoryServiceImpl implements DirectoryService {
             log.error("Failed to get all root directories:", e);
             throw new DatabaseException("Die Wurzelverzeichnisse konnten nicht geladen werden!", e);
         }
+    }
+
+    /**
+     * Sanitizes a folder name.
+     *
+     * @param folderName the folder name
+     * @return sanitized String
+     */
+    @SuppressWarnings("PMD.LawOfDemeter")
+    private String sanitizeName(String folderName) {
+        final int maxSize = 255;
+        String sanitizedFolderName = folderName.replaceAll("[^öÖäÄüÜa-zA-Z0-9()._-]", "_");
+
+        if (sanitizedFolderName.length() > maxSize) {
+            sanitizedFolderName = sanitizedFolderName.substring(0, maxSize);
+        }
+        return sanitizedFolderName;
     }
 }

--- a/src/main/java/mops/businesslogic/file/FileServiceImpl.java
+++ b/src/main/java/mops/businesslogic/file/FileServiceImpl.java
@@ -294,7 +294,6 @@ public class FileServiceImpl implements FileService {
             throw new EmptyNameException("Der Dateiname darf nicht leer sein.");
         }
 
-        newName = sanitizeName(newName);
 
         FileInfo fileInfo = fileInfoService.fetchFileInfo(fileId);
         Directory directory = directoryService.getDirectory(fileInfo.getDirectoryId());
@@ -310,9 +309,11 @@ public class FileServiceImpl implements FileService {
         String[] fileNameParts = fileInfo.getName().split("\\.");
         if (fileNameParts.length > 1) {
             String fileExtension = "." + fileNameParts[fileNameParts.length - 1];
-            fileInfo.setName(newName + fileExtension);
+            newName = sanitizeName(newName + fileExtension);
+            fileInfo.setName(newName);
         } else {
             // file had no extension
+            newName = sanitizeName(newName);
             fileInfo.setName(newName);
         }
 
@@ -338,6 +339,7 @@ public class FileServiceImpl implements FileService {
                 String fileExtension = "." + fileNameParts[fileNameParts.length - 1];
                 sanitizedFilename = sanitizedFilename.substring(0, maxSize - fileExtension.length());
                 sanitizedFilename = sanitizedFilename.concat(fileExtension);
+
             } else {
                 sanitizedFilename = sanitizedFilename.substring(0, maxSize);
             }

--- a/src/main/java/mops/businesslogic/file/FileServiceImpl.java
+++ b/src/main/java/mops/businesslogic/file/FileServiceImpl.java
@@ -346,7 +346,6 @@ public class FileServiceImpl implements FileService {
                 String fileExtension = "." + fileNameParts[fileNameParts.length - 1];
                 sanitizedFilename = sanitizedFilename.substring(0, maxSize - fileExtension.length());
                 sanitizedFilename = sanitizedFilename.concat(fileExtension);
-
             } else {
                 sanitizedFilename = sanitizedFilename.substring(0, maxSize);
             }

--- a/src/main/java/mops/businesslogic/file/FileServiceImpl.java
+++ b/src/main/java/mops/businesslogic/file/FileServiceImpl.java
@@ -294,7 +294,7 @@ public class FileServiceImpl implements FileService {
             throw new EmptyNameException("Der Dateiname darf nicht leer sein.");
         }
 
-        newName = newName.replaceAll("[^a-zA-Z0-9._-]", "_");
+        newName = sanitizeName(newName);
 
         FileInfo fileInfo = fileInfoService.fetchFileInfo(fileId);
         Directory directory = directoryService.getDirectory(fileInfo.getDirectoryId());
@@ -318,5 +318,30 @@ public class FileServiceImpl implements FileService {
 
         fileInfoService.saveFileInfo(fileInfo);
         return directory;
+    }
+
+    /**
+     * Sanitizes a filename.
+     *
+     * @param filename the filename
+     * @return sanitized String
+     */
+    @SuppressWarnings({ "PMD.AvoidLiteralsInIfCondition", "PMD.LawOfDemeter" })
+    private String sanitizeName(String filename) {
+        final int maxSize = 255;
+        String sanitizedFilename = filename.replaceAll("[^öÖäÄüÜa-zA-Z0-9()._-]", "_");
+
+        if (sanitizedFilename.length() > maxSize) {
+            String[] fileNameParts = sanitizedFilename.split("\\.");
+            if (fileNameParts.length > 1) {
+                // with extension
+                String fileExtension = "." + fileNameParts[fileNameParts.length - 1];
+                sanitizedFilename = sanitizedFilename.substring(0, maxSize - fileExtension.length());
+                sanitizedFilename = sanitizedFilename.concat(fileExtension);
+            } else {
+                sanitizedFilename = sanitizedFilename.substring(0, maxSize);
+            }
+        }
+        return sanitizedFilename;
     }
 }


### PR DESCRIPTION
Allows now umlauts and brackets. Additionally checks the length and abbreviates to 255 characters.
I've chosen 255 because of the limits of the most commonly used filesystems:
ext3, ext4: 255
HFS+, APFS: 255
NTFS: 255
[Source](https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits)

I know that the database would just throw an error when saving over 255 characters, but an abbreviation is just nicer than an error I guess.